### PR TITLE
Fixed gulpfile typo from `styles` to `less`

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -127,7 +127,7 @@ gulp.task('serve', ['produce'], function () {
     '.tmp/fonts/**/*'
   ]).on('change', reload);
 
-  gulp.watch('app/styles/**/*.<%= includeLess ? 'less' : 'css' %>', ['styles']);
+  gulp.watch('app/styles/**/*.<%= includeLess ? 'less' : 'css' %>', ['less']);
   gulp.watch('app/fonts/**/*', ['fonts']);
   gulp.watch('bower.json', ['wiredep', 'fonts']);
   gulp.watch('app/scripts/**/*.js', ['es6']);


### PR DESCRIPTION
When changes to less files happened it would kill the server because there is no `styles` task defined.
